### PR TITLE
Speedrun Mode Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -332,3 +332,9 @@ ASALocalRun/
 
 # Local History for Visual Studio
 .localhistory/
+
+# Compiled
+Compiled/
+packages/
+Release
+

--- a/BananaModManager.Loader.IL2Cpp/BananaModManager.Loader.IL2Cpp.csproj
+++ b/BananaModManager.Loader.IL2Cpp/BananaModManager.Loader.IL2Cpp.csproj
@@ -43,35 +43,20 @@
       <HintPath>..\packages\HarmonyX.2.10.0\lib\net45\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp">
-      <HintPath>E:\Steam\steamapps\common\smbbm\managed\Assembly-CSharp.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>H:\SteamLibrary\steamapps\common\smbbm\managed\Assembly-CSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="Il2CppMono.Security">
+      <HintPath>H:\SteamLibrary\steamapps\common\smbbm\managed\Il2CppMono.Security.dll</HintPath>
     </Reference>
     <Reference Include="Il2Cppmscorlib">
-      <HintPath>E:\Steam\steamapps\common\smbbm\unhollowed\Il2Cppmscorlib.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>H:\SteamLibrary\steamapps\common\smbbm\managed\Il2Cppmscorlib.dll</HintPath>
     </Reference>
     <Reference Include="Il2CppSystem">
-      <HintPath>E:\Steam\steamapps\common\smbbm\unhollowed\Il2CppSystem.dll</HintPath>
+      <HintPath>H:\SteamLibrary\steamapps\common\smbbm\managed\Il2CppSystem.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Il2CppSystem.Configuration">
-      <HintPath>E:\Steam\steamapps\common\smbbm\unhollowed\Il2CppSystem.Configuration.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Il2CppSystem.Core">
-      <HintPath>E:\Steam\steamapps\common\smbbm\unhollowed\Il2CppSystem.Core.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Il2CppSystem.Runtime.Serialization">
-      <HintPath>E:\Steam\steamapps\common\smbbm\unhollowed\Il2CppSystem.Runtime.Serialization.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Il2CppSystem.Xml">
-      <HintPath>E:\Steam\steamapps\common\smbbm\unhollowed\Il2CppSystem.Xml.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Il2CppSystem.Xml.Linq">
-      <HintPath>E:\Steam\steamapps\common\smbbm\unhollowed\Il2CppSystem.Xml.Linq.dll</HintPath>
+      <HintPath>H:\SteamLibrary\steamapps\common\smbbm\managed\Il2CppSystem.Configuration.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Mono.Cecil, Version=0.11.4.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
@@ -101,44 +86,36 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="UnhollowerBaseLib">
-      <HintPath>E:\Steam\steamapps\common\smbbm\unhollowed\UnhollowerBaseLib.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>H:\SteamLibrary\steamapps\common\smbbm\managed\UnhollowerBaseLib.dll</HintPath>
     </Reference>
     <Reference Include="UnhollowerRuntimeLib">
-      <HintPath>E:\Steam\steamapps\common\smbbm\unhollowed\UnhollowerRuntimeLib.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>H:\SteamLibrary\steamapps\common\smbbm\managed\UnhollowerRuntimeLib.dll</HintPath>
     </Reference>
     <Reference Include="Unity.InputSystem">
-      <HintPath>E:\Steam\steamapps\common\smbbm\unhollowed\Unity.InputSystem.dll</HintPath>
+      <HintPath>H:\SteamLibrary\steamapps\common\smbbm\managed\Unity.InputSystem.dll</HintPath>
     </Reference>
     <Reference Include="Unity.Mathematics">
-      <HintPath>E:\Steam\steamapps\common\smbbm\unhollowed\Unity.Mathematics.dll</HintPath>
+      <HintPath>H:\SteamLibrary\steamapps\common\smbbm\managed\Unity.Mathematics.dll</HintPath>
     </Reference>
     <Reference Include="Unity.Postprocessing.Runtime">
-      <HintPath>E:\Steam\steamapps\common\smbbm\unhollowed\Unity.Postprocessing.Runtime.dll</HintPath>
+      <HintPath>H:\SteamLibrary\steamapps\common\smbbm\managed\Unity.Postprocessing.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="Unity.TextMeshPro">
-      <HintPath>E:\Steam\steamapps\common\smbbm\unhollowed\Unity.TextMeshPro.dll</HintPath>
-    </Reference>
-    <Reference Include="Unity.Timeline">
-      <HintPath>E:\Steam\steamapps\common\smbbm\unhollowed\Unity.Timeline.dll</HintPath>
+      <HintPath>H:\SteamLibrary\steamapps\common\smbbm\managed\Unity.TextMeshPro.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine">
-      <HintPath>E:\Steam\steamapps\common\smbbm\unhollowed\UnityEngine.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\..\References\UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>E:\Steam\steamapps\common\smbbm\unhollowed\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>H:\SteamLibrary\steamapps\common\smbbm\managed\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.IMGUIModule">
-      <HintPath>E:\Steam\steamapps\common\smbbm\unhollowed\UnityEngine.IMGUIModule.dll</HintPath>
+      <HintPath>H:\SteamLibrary\steamapps\common\smbbm\managed\UnityEngine.IMGUIModule.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="AssetBundle.cs" />
     <Compile Include="CodeRunner.cs" />
     <Compile Include="Loader.cs" />
-    <Compile Include="Patches.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="UnhollowerDetour.cs" />
   </ItemGroup>

--- a/BananaModManager.Loader.IL2Cpp/Loader.cs
+++ b/BananaModManager.Loader.IL2Cpp/Loader.cs
@@ -276,8 +276,6 @@ namespace BananaModManager.Loader.IL2Cpp
             {
                 DrawTextOutline(new Rect(Screen.width - offset.x - offset2 + _modListSlide, offset.y + style.fontSize * i, offset2 - offset.x, style.fontSize),
                     _hashList[i].Item1, outlineSize, style);
-                DrawTextOutline(new Rect(Screen.width - offset.x + _modListSlide, offset.y + style.fontSize * i, Screen.width, style.fontSize),
-                    _hashList[i].Item2, outlineSize, style);
             }
         }
 

--- a/BananaModManager.Loader.IL2Cpp/Loader.cs
+++ b/BananaModManager.Loader.IL2Cpp/Loader.cs
@@ -92,14 +92,17 @@ namespace BananaModManager.Loader.IL2Cpp
                     {
                         Thread.Sleep(12000);
 
-                        if (Mods.Count > 0 && _speedrunMode == false)
+                        if (Mods.Count > 0 && !_speedrunMode)
                         {
                             LeaderboardsDelegateInstance = Dummy;
 
                             ClassInjector.Detour.Detour(IntPtr.Add(GetModuleHandle("GameAssembly.dll"), 0xa9d990),
                                 LeaderboardsDelegateInstance);
                         }
-
+                        if (Mods.Count > 0 && _speedrunMode)
+                        {
+                            Console.WriteLine("1 Line of Code Later...");
+                        }
                         Console.WriteLine("Initializing the mods...");
                         CreateCodeRunner();
                     }

--- a/BananaModManager.Loader.IL2Cpp/Loader.cs
+++ b/BananaModManager.Loader.IL2Cpp/Loader.cs
@@ -92,7 +92,7 @@ namespace BananaModManager.Loader.IL2Cpp
                     {
                         Thread.Sleep(12000);
 
-                        if (Mods.Count > 0)
+                        if (Mods.Count > 0 && _speedrunMode == false)
                         {
                             LeaderboardsDelegateInstance = Dummy;
 

--- a/BananaModManager.Loader.IL2Cpp/Loader.cs
+++ b/BananaModManager.Loader.IL2Cpp/Loader.cs
@@ -34,7 +34,7 @@ namespace BananaModManager.Loader.IL2Cpp
         private static List<Mod> _mods;
         private static bool _speedrunMode;
 
-        private static List<Tuple<string, string>> _hashList = new List<Tuple<string, string>>();
+        private static List<string> _SpeedrunList = new List<string>();
         private static float _modListSlide = 1f;
 
         public static List<Mod> Mods => _mods;
@@ -135,14 +135,12 @@ namespace BananaModManager.Loader.IL2Cpp
                 // Calculate the hashes to display in the speedrun mode
                 if (_speedrunMode)
                 {
-                    Console.WriteLine("Calculating the hashes.");
+                    Console.WriteLine("Passing mod names to Speedrun Mode display...");
 
                     foreach (var t in Mods)
                     {
                         var name = t.Info.Title;
-                        var hash = Hash(t.Info.Id + new FileInfo(t.GetFullPath()).Length);
-
-                        _hashList.Add(new Tuple<string, string>(name, hash));
+                        _SpeedrunList.Add(name);
                     }
                 }
 
@@ -272,30 +270,11 @@ namespace BananaModManager.Loader.IL2Cpp
             var outlineSize = (int)Mathf.Ceil(ratio);
 
             // Draw them all
-            for (var i = 0; i < _hashList.Count; i++)
+            for (var i = 0; i < _SpeedrunList.Count; i++)
             {
                 DrawTextOutline(new Rect(Screen.width - offset.x - offset2 + _modListSlide, offset.y + style.fontSize * i, offset2 - offset.x, style.fontSize),
-                    _hashList[i].Item1, outlineSize, style);
+                    _SpeedrunList[i], outlineSize, style);
             }
-        }
-
-        private static string Hash(string str)
-        {
-            var allowedSymbols = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz".ToCharArray();
-            const int length = 6;
-            var hash = new char[length];
-
-            for (var i = 0; i < str.Length; i++)
-            {
-                hash[i % length] = (char)(hash[i % length] ^ str[i]);
-            }
-
-            for (var i = 0; i < length; i++)
-            {
-                hash[i] = allowedSymbols[hash[i] % allowedSymbols.Length];
-            }
-
-            return new string(hash);
         }
 
         private static void DrawTextOutline(Rect r, string t, int strength, GUIStyle style)

--- a/BananaModManager.Loader.Mono/BananaModManager.Loader.Mono.csproj
+++ b/BananaModManager.Loader.Mono/BananaModManager.Loader.Mono.csproj
@@ -49,6 +49,9 @@
     <Reference Include="Il2Cppmscorlib">
       <HintPath>..\..\References\Il2Cppmscorlib.dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -79,6 +82,7 @@
     <None Include="doorstop_config_mono.ini">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\BananaModManager.Shared\BananaModManager.Shared.csproj">

--- a/BananaModManager.Loader.Mono/BananaModManager.Loader.Mono.csproj
+++ b/BananaModManager.Loader.Mono/BananaModManager.Loader.Mono.csproj
@@ -43,6 +43,12 @@
     <DebugSymbols>false</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Assembly-CSharp">
+      <HintPath>H:\SteamLibrary\steamapps\common\smbbm\managed\Assembly-CSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="Il2Cppmscorlib">
+      <HintPath>..\..\References\Il2Cppmscorlib.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -50,10 +56,17 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>E:\Steam\steamapps\common\SMBBBHD\SMBBBHD_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="UnhollowerBaseLib">
+      <HintPath>..\..\References\UnhollowerBaseLib.dll</HintPath>
+    </Reference>
+    <Reference Include="UnhollowerRuntimeLib">
+      <HintPath>..\..\References\UnhollowerRuntimeLib.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine">
+      <HintPath>..\..\References\UnityEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.CoreModule">
+      <HintPath>..\..\References\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/BananaModManager.Loader.Mono/packages.config
+++ b/BananaModManager.Loader.Mono/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net472" />
+  <package id="SharpZipLib" version="1.3.2" targetFramework="net472" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net472" />
+</packages>

--- a/BananaModManager.Shared/Game.cs
+++ b/BananaModManager.Shared/Game.cs
@@ -35,9 +35,14 @@ namespace BananaModManager
         public bool Managed = false;
 
         /// <summary>
-        ///     Names of the allowed mods in the speedrun mode.
+        ///     Hashes of the alowed mods in speedrun mode.
         /// </summary>
         public List<string> Whitelist = new List<string>();
+        /// <summary>
+        ///     Names of the allowed mods in speedrun mode.
+        /// </summary>
+        public List<string> WhitelistNames = new List<string>();
+        /// <returns></returns>
 
         public override string ToString()
         {

--- a/BananaModManager.Shared/Games.cs
+++ b/BananaModManager.Shared/Games.cs
@@ -20,12 +20,30 @@ namespace BananaModManager
             AppID = "1316910",
             Managed = false,
             Whitelist = new List<string>() {
-                "bm.mors.graphicaltweaks",
-                "bm.ceejiggy.noprompt",
-                "bm.snowman.dynamicroll",
-                "bm.snowman.guestcharacter",
-                "bm.viictiinii.timersound",
-                "iswimfly.HUD",
+                //Graphical Tweaks
+                "D79D69527DF63DDF35389DD05464A655BCE156CA484026E3249F7576250A6A14",
+                // No Prompt
+                "B678793A497954A4E05A76352781A07EC209087946506308E1E7722D5F2BFBAD",
+                // Dynamic Roll
+                "5B0BA8297E40FCF0ACFA47A6E2B12BB65DA96BD96202AF4C242715F31EEE2BDC",
+                // Guest Characters
+                "27F4B47A9F37B36BAC14FC4B10C7CBA399D7571E7879CADE9C961697CAE6F8FB",
+                // Timer Sound
+                "F62DB98D3F1F77717ACE38D706EA431663780EBF5BBB8A751010B92F24AA889F",
+                // UI
+                "62B4D876FF957A5E681E8820B0CAD61126A86B5890DB6C6FB23CF32BCFCFD517",
+                // IL timer
+                "66D05F13336A3354A5A34C41598E85FC8C02DBA7ADEE51505EDD3D39BE8096B3"
+            },
+            WhitelistNames = new List<string>
+            {
+                "GraphicalTweaks.dll",
+                "NoPrompt.dll",
+                "DynamicSounds.dll",
+                "GuestCharacters.dll",
+                "TimerSound.dll",
+                "UI Enhancements.dll",
+                "ILBattleTimer.dll"
             }
         };
 

--- a/BananaModManager.sln
+++ b/BananaModManager.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31205.134
+# Visual Studio Version 17
+VisualStudioVersion = 17.2.32526.322
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BananaModManager.Loader.Mono", "BananaModManager.Loader.Mono\BananaModManager.Loader.Mono.csproj", "{6F89DD11-195B-4638-9553-36196B584397}"
 EndProject

--- a/BananaModManager/BananaModManager.csproj
+++ b/BananaModManager/BananaModManager.csproj
@@ -46,16 +46,17 @@
     <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>H:\SteamLibrary\steamapps\common\smbbm\managed\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
     </Reference>
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
-    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
-    </Reference>
     <Reference Include="System.Numerics" />
     <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>H:\SteamLibrary\steamapps\common\smbbm\managed\System.Numerics.Vectors.dll</HintPath>
@@ -82,11 +83,17 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Deployment" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="OneClickConfirmation.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="OneClickConfirmation.Designer.cs">
+      <DependentUpon>OneClickConfirmation.cs</DependentUpon>
+    </Compile>
+    <Compile Include="GameBanana.cs" />
     <Compile Include="ConfigPropertyDescriptor.cs" />
     <Compile Include="ConfigPropertyGridAdapter.cs" />
     <Compile Include="MainForm.cs">
@@ -100,6 +107,9 @@
     <Compile Include="Steam.cs" />
     <EmbeddedResource Include="MainForm.resx">
       <DependentUpon>MainForm.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="OneClickConfirmation.resx">
+      <DependentUpon>OneClickConfirmation.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>

--- a/BananaModManager/BananaModManager.csproj
+++ b/BananaModManager/BananaModManager.csproj
@@ -44,7 +44,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.5.0.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+      <HintPath>H:\SteamLibrary\steamapps\common\smbbm\managed\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
@@ -58,19 +58,19 @@
     </Reference>
     <Reference Include="System.Numerics" />
     <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+      <HintPath>H:\SteamLibrary\steamapps\common\smbbm\managed\System.Numerics.Vectors.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.5.0.0\lib\net45\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+      <HintPath>H:\SteamLibrary\steamapps\common\smbbm\managed\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Text.Encodings.Web, Version=5.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Text.Encodings.Web.5.0.1\lib\net461\System.Text.Encodings.Web.dll</HintPath>
+      <HintPath>H:\SteamLibrary\steamapps\common\smbbm\managed\System.Text.Encodings.Web.dll</HintPath>
     </Reference>
     <Reference Include="System.Text.Json, Version=5.0.0.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Text.Json.5.0.2\lib\net461\System.Text.Json.dll</HintPath>
+      <HintPath>H:\SteamLibrary\steamapps\common\smbbm\managed\System.Text.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+      <HintPath>H:\SteamLibrary\steamapps\common\smbbm\managed\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net47\System.ValueTuple.dll</HintPath>

--- a/BananaModManager/GameBanana.cs
+++ b/BananaModManager/GameBanana.cs
@@ -78,6 +78,10 @@ namespace BananaModManager
                 catch (IOException)
                 {
                     MessageBox.Show("The mod is already installed! Updating Mods will come soon...");
+                    if (File.Exists(AppDomain.CurrentDomain.BaseDirectory + "\\mods\\" + fileName))
+                    {
+                        File.Delete(AppDomain.CurrentDomain.BaseDirectory + "\\mods\\" + fileName);
+                    }
                 }
             }
         }

--- a/BananaModManager/GameBanana.cs
+++ b/BananaModManager/GameBanana.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.IO.Compression;
+using System.IO;
+using System.Collections.Generic;
+using System.Reflection;
+using Microsoft.Win32;
+using System.Windows.Forms;
+using System.Threading.Tasks;
+using System.Runtime.Serialization;
+using System.Net.Http;
+using Newtonsoft.Json;
+using System.Text;
+using System.Net;
+
+namespace BananaModManager
+{
+    public static class GameBanana
+    {
+        public static Dictionary<string, string> parsedJson;
+        // Upon launching the Mod Manager, this enables one-click capability.
+        public static bool InstallOneClick()
+        {
+            string ExeDirectory = Path.ChangeExtension(Assembly.GetExecutingAssembly().Location, ".exe");
+            string protocol = $"bananamodmanager";
+            try
+            {
+                var reg = Registry.CurrentUser.CreateSubKey(@"Software\Classes\BananaModManager");
+                reg.SetValue("", $"URL:{protocol}");
+                reg.SetValue("URL Protocol", "");
+                reg = reg.CreateSubKey(@"shell\open\command");
+                reg.SetValue("", $"\"{ExeDirectory}\" -download \"%1\"");
+                reg.Close();
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        public static void ParseData(string gbID)
+        {
+            // Use Mod ID to find files 
+            string urlRequest = $"https://api.gamebanana.com/Core/Item/Data?itemtype=Mod&itemid={gbID}&fields=Files().aFiles()&format=json_min&flags=JSON_UNESCAPED_SLASHES";
+            using (WebClient wc = new WebClient())
+            {
+                var jsondata = wc.DownloadString(urlRequest);
+                //fix the formatting so it can be parsed
+                jsondata = jsondata.Remove(0, 11);
+                jsondata = jsondata.Remove(jsondata.Length - 2, 2);
+                parsedJson = JsonConvert.DeserializeObject<Dictionary<string, string>>(jsondata);
+            }
+
+
+            WebClient x = new WebClient();
+        }
+
+        public static void DownloadArchive(Dictionary<string, string> modInfo)
+        {
+            StringBuilder sb = new StringBuilder();
+
+            foreach (var item in modInfo)
+            {
+                sb.AppendFormat("{0} - {1}{2}", item.Key, item.Value, Environment.NewLine);
+            }
+
+            string downloadlink = modInfo["_sDownloadUrl"];
+            string fileName = modInfo["_sFile"];
+            using (var client = new WebClient())
+            {
+                try
+                {
+                    client.DownloadFile(downloadlink, AppDomain.CurrentDomain.BaseDirectory + "\\mods\\" + fileName);
+                    ZipFile.ExtractToDirectory(AppDomain.CurrentDomain.BaseDirectory + "\\mods\\" + fileName, AppDomain.CurrentDomain.BaseDirectory + "\\mods\\");
+                    File.Delete(AppDomain.CurrentDomain.BaseDirectory + "\\mods\\" + fileName);
+                    MessageBox.Show("Success!");
+                }
+                catch (IOException)
+                {
+                    MessageBox.Show("The mod is already installed! Updating Mods will come soon...");
+                }
+            }
+        }
+
+        public static void ModDownload(string gamebananaUrl)
+        {
+            string modID = gamebananaUrl.Substring(gamebananaUrl.Length - 6);
+            ParseData(modID);
+            DownloadArchive(parsedJson);
+        }
+    }
+}

--- a/BananaModManager/MainForm.Designer.cs
+++ b/BananaModManager/MainForm.Designer.cs
@@ -56,13 +56,13 @@ namespace BananaModManager
             this.BtnSave = new System.Windows.Forms.Button();
             this.BtnPlay = new System.Windows.Forms.Button();
             this.PageSettings = new System.Windows.Forms.TabPage();
+            this.BtnSave2 = new System.Windows.Forms.Button();
             this.PanelSettings = new System.Windows.Forms.FlowLayoutPanel();
             this.LabelGame = new System.Windows.Forms.Label();
             this.ComboGames = new System.Windows.Forms.ComboBox();
             this.CheckConsole = new System.Windows.Forms.CheckBox();
             this.CheckSpeedrun = new System.Windows.Forms.CheckBox();
             this.label1 = new System.Windows.Forms.Label();
-            this.BtnSave2 = new System.Windows.Forms.Button();
             this.PageAbout = new System.Windows.Forms.TabPage();
             this.TextInfo = new System.Windows.Forms.TextBox();
             this.LabelAboutVersion = new System.Windows.Forms.Label();
@@ -140,6 +140,7 @@ namespace BananaModManager
             this.TabControl.TabBackColor = System.Drawing.SystemColors.Control;
             this.TabControl.TabColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(122)))), ((int)(((byte)(204)))));
             this.TabControl.TabIndex = 6;
+            this.TabControl.SelectedIndexChanged += new System.EventHandler(this.TabControl_SelectedIndexChanged);
             // 
             // PageMods
             // 
@@ -202,7 +203,7 @@ namespace BananaModManager
             this.ContainerList.Panel2.Controls.Add(this.LabelTitle);
             this.ContainerList.Panel2.Controls.Add(this.TextDescription);
             this.ContainerList.Size = new System.Drawing.Size(409, 339);
-            this.ContainerList.SplitterDistance = 256;
+            this.ContainerList.SplitterDistance = 259;
             this.ContainerList.SplitterWidth = 3;
             this.ContainerList.TabIndex = 0;
             // 
@@ -221,7 +222,7 @@ namespace BananaModManager
             this.ListMods.Location = new System.Drawing.Point(0, 0);
             this.ListMods.Margin = new System.Windows.Forms.Padding(2);
             this.ListMods.Name = "ListMods";
-            this.ListMods.Size = new System.Drawing.Size(409, 256);
+            this.ListMods.Size = new System.Drawing.Size(409, 259);
             this.ListMods.TabIndex = 9;
             this.ListMods.UseCompatibleStateImageBehavior = false;
             this.ListMods.View = System.Windows.Forms.View.Details;
@@ -264,7 +265,7 @@ namespace BananaModManager
             this.TextDescription.Multiline = true;
             this.TextDescription.Name = "TextDescription";
             this.TextDescription.ReadOnly = true;
-            this.TextDescription.Size = new System.Drawing.Size(409, 80);
+            this.TextDescription.Size = new System.Drawing.Size(409, 77);
             this.TextDescription.TabIndex = 0;
             // 
             // GridConfig
@@ -341,6 +342,16 @@ namespace BananaModManager
             this.PageSettings.TabIndex = 1;
             this.PageSettings.Text = "Settings";
             // 
+            // BtnSave2
+            // 
+            this.BtnSave2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.BtnSave2.Location = new System.Drawing.Point(510, 383);
+            this.BtnSave2.Name = "BtnSave2";
+            this.BtnSave2.Size = new System.Drawing.Size(103, 26);
+            this.BtnSave2.TabIndex = 9;
+            this.BtnSave2.Text = "Save";
+            this.BtnSave2.Click += new System.EventHandler(this.BtnSave2_Click);
+            // 
             // PanelSettings
             // 
             this.PanelSettings.Controls.Add(this.LabelGame);
@@ -408,16 +419,6 @@ namespace BananaModManager
             this.label1.TabIndex = 4;
             this.label1.Text = "(Enables the leaderboards, but only allows whitelisted mods, and displays active " +
     "mods on the screen.)";
-            // 
-            // BtnSave2
-            // 
-            this.BtnSave2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.BtnSave2.Location = new System.Drawing.Point(510, 383);
-            this.BtnSave2.Name = "BtnSave2";
-            this.BtnSave2.Size = new System.Drawing.Size(103, 26);
-            this.BtnSave2.TabIndex = 9;
-            this.BtnSave2.Text = "Save";
-            this.BtnSave2.Click += new System.EventHandler(this.BtnSave2_Click);
             // 
             // PageAbout
             // 

--- a/BananaModManager/MainForm.cs
+++ b/BananaModManager/MainForm.cs
@@ -286,5 +286,10 @@ namespace BananaModManager
         {
             BtnSave_Click(sender, e);
         }
+
+        private void TabControl_SelectedIndexChanged(object sender, EventArgs e)
+        {
+
+        }
     }
 }

--- a/BananaModManager/MainForm.cs
+++ b/BananaModManager/MainForm.cs
@@ -17,7 +17,8 @@ namespace BananaModManager
         public MainForm()
         {
             InitializeComponent();
-
+            // Try to create registry entry for One-Click install
+            GameBanana.InstallOneClick();
             // Load the games
             foreach (var game in Games.List)
             {

--- a/BananaModManager/MainForm.resx
+++ b/BananaModManager/MainForm.resx
@@ -117,13 +117,12 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="MenuConfig.TrayLocation" type="System.Drawing.Point, System.Drawing">
+  <metadata name="MenuConfig.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
-  </data>
-  <data name="MenuMods.TrayLocation" type="System.Drawing.Point, System.Drawing">
+  </metadata>
+  <metadata name="MenuMods.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>136, 17</value>
-  </data>
+  </metadata>
   <data name="TextInfo.Text" xml:space="preserve">
     <value>A mod manager for Super Monkey Ball games that are made in Unity.
 

--- a/BananaModManager/OneClickConfirmation.Designer.cs
+++ b/BananaModManager/OneClickConfirmation.Designer.cs
@@ -1,4 +1,8 @@
-﻿namespace BananaModManager
+﻿using System;
+using System.Net;
+using System.Text.RegularExpressions;
+
+namespace BananaModManager
 {
     partial class OneClickConfirmation
     {
@@ -26,6 +30,31 @@
         /// Required method for Designer support - do not modify
         /// the contents of this method with the code editor.
         /// </summary>
+        /// 
+
+        public static string GetPageTitle(string link)
+        {
+            try
+            {
+                WebClient wc = new WebClient();
+                string html = wc.DownloadString(link);
+
+                Regex x = new Regex("<title>(.*)</title>");
+                MatchCollection m = x.Matches(html);
+
+                if (m.Count > 0)
+                {
+                    return m[0].Value.Replace("<title>", "").Replace("</title>", "");
+                }
+                else
+                    return "";
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("Could not connect. Error:" + ex.Message);
+                return "";
+            }
+        }
         private void InitializeComponent()
         {
             this.ModLink = new System.Windows.Forms.LinkLabel();
@@ -42,7 +71,7 @@
             this.ModLink.Size = new System.Drawing.Size(91, 13);
             this.ModLink.TabIndex = 0;
             this.ModLink.TabStop = true;
-            this.ModLink.Text = passedUrl;
+            this.ModLink.Text = GetPageTitle(passedUrl).Remove(GetPageTitle(passedUrl).Length - 40, 40);
             this.ModLink.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             this.ModLink.Dock = System.Windows.Forms.DockStyle.Fill;
             this.ModLink.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.ModLink_LinkClicked);
@@ -87,7 +116,7 @@
             this.Controls.Add(this.InstallText);
             this.Controls.Add(this.ModLink);
             this.Name = "OneClickConfirmation";
-            this.Text = "Form1";
+            this.Text = "One-Click Mod Install";
             this.Load += new System.EventHandler(this.OneClickConfirmation_Load);
             this.ResumeLayout(false);
             this.PerformLayout();

--- a/BananaModManager/OneClickConfirmation.Designer.cs
+++ b/BananaModManager/OneClickConfirmation.Designer.cs
@@ -1,0 +1,104 @@
+﻿namespace BananaModManager
+{
+    partial class OneClickConfirmation
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.ModLink = new System.Windows.Forms.LinkLabel();
+            this.InstallText = new System.Windows.Forms.Label();
+            this.ConfirmInstall = new System.Windows.Forms.Button();
+            this.DeconfirmInstall = new System.Windows.Forms.Button();
+            this.SuspendLayout();
+            // 
+            // ModLink
+            // 
+            this.ModLink.AutoSize = false;
+            this.ModLink.Location = new System.Drawing.Point(191, 40);
+            this.ModLink.Name = "ModLink";
+            this.ModLink.Size = new System.Drawing.Size(91, 13);
+            this.ModLink.TabIndex = 0;
+            this.ModLink.TabStop = true;
+            this.ModLink.Text = passedUrl;
+            this.ModLink.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.ModLink.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.ModLink.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.ModLink_LinkClicked);
+            // 
+            // InstallText
+            // 
+            this.InstallText.AutoSize = true;
+            this.InstallText.Location = new System.Drawing.Point(130, 20);
+            this.InstallText.Name = "InstallText";
+            this.InstallText.Size = new System.Drawing.Size(91, 13);
+            this.InstallText.TabIndex = 1;
+            this.InstallText.TextAlign = System.Drawing.ContentAlignment.TopCenter;
+            this.InstallText.Text = "Would you like to install this Mod?";
+            // 
+            // ConfirmInstall
+            // 
+            this.ConfirmInstall.Location = new System.Drawing.Point(97, 100);
+            this.ConfirmInstall.Name = "ConfirmInstall";
+            this.ConfirmInstall.Size = new System.Drawing.Size(75, 23);
+            this.ConfirmInstall.TabIndex = 2;
+            this.ConfirmInstall.Text = "Install";
+            this.ConfirmInstall.UseVisualStyleBackColor = true;
+            this.ConfirmInstall.Click += new System.EventHandler(this.ConfirmInstall_Click);
+            // 
+            // DeconfirmInstall
+            // 
+            this.DeconfirmInstall.Location = new System.Drawing.Point(257, 100);
+            this.DeconfirmInstall.Name = "DeconfirmInstall";
+            this.DeconfirmInstall.Size = new System.Drawing.Size(75, 23);
+            this.DeconfirmInstall.TabIndex = 3;
+            this.DeconfirmInstall.Text = "Close";
+            this.DeconfirmInstall.UseVisualStyleBackColor = true;
+            this.DeconfirmInstall.Click += new System.EventHandler(this.DeconfirmInstall_Click);
+            // 
+            // OneClickConfirmation
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(437, 148);
+            this.Controls.Add(this.DeconfirmInstall);
+            this.Controls.Add(this.ConfirmInstall);
+            this.Controls.Add(this.InstallText);
+            this.Controls.Add(this.ModLink);
+            this.Name = "OneClickConfirmation";
+            this.Text = "Form1";
+            this.Load += new System.EventHandler(this.OneClickConfirmation_Load);
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.LinkLabel ModLink;
+        private System.Windows.Forms.Label InstallText;
+        private System.Windows.Forms.Button ConfirmInstall;
+        private System.Windows.Forms.Button DeconfirmInstall;
+    }
+}

--- a/BananaModManager/OneClickConfirmation.cs
+++ b/BananaModManager/OneClickConfirmation.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace BananaModManager
+{
+    public partial class OneClickConfirmation : Form
+    {
+        public static string passedUrl = "";
+        public OneClickConfirmation(string modURL)
+        {
+            passedUrl = modURL;
+            InitializeComponent();
+        }
+
+        private void OneClickConfirmation_Load(object sender, EventArgs e)
+        {
+
+        }
+
+        private void ModLink_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+        {
+            try 
+            {
+                VisitLink(passedUrl);
+            }
+            catch (Exception ex)
+            {
+
+            }
+        }
+        private void VisitLink(string modURL)
+        {
+            ModLink.LinkVisited = true;
+            System.Diagnostics.Process.Start(modURL);  
+        }
+
+        private void ConfirmInstall_Click(object sender, EventArgs e)
+        {
+            GameBanana.ModDownload(passedUrl);
+        }
+
+        private void DeconfirmInstall_Click(object sender, EventArgs e)
+        {
+            this.Close();
+        }
+    }
+
+}

--- a/BananaModManager/OneClickConfirmation.resx
+++ b/BananaModManager/OneClickConfirmation.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/BananaModManager/Program.cs
+++ b/BananaModManager/Program.cs
@@ -3,18 +3,27 @@ using System.Windows.Forms;
 
 namespace BananaModManager
 {
-    internal static class Program
+    public static class Program
     {
         /// <summary>
         ///     The main entry point for the application.
         /// </summary>
         [STAThread]
-        private static void Main()
+        static void Main(string[] args)
         {
-            //Application.SetHighDpiMode(HighDpiMode.SystemAware);
-            Application.EnableVisualStyles();
-            Application.SetCompatibleTextRenderingDefault(false);
-            Application.Run(new MainForm());
+            if(args.Length > 0 && args[0] == "-download")
+            {
+                string modURL = args[1];
+                modURL = modURL.Remove(0, 17);
+                Application.Run(new OneClickConfirmation(modURL));
+            }
+            else
+            {
+                //Application.SetHighDpiMode(HighDpiMode.SystemAware);
+                Application.EnableVisualStyles();
+                Application.SetCompatibleTextRenderingDefault(false);
+                Application.Run(new MainForm());
+            }
         }
     }
 }

--- a/BananaModManager/Properties/AssemblyInfo.cs
+++ b/BananaModManager/Properties/AssemblyInfo.cs
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.9.3.0")]
-[assembly: AssemblyFileVersion("0.9.3.0")]
+[assembly: AssemblyVersion("0.9.4.0")]
+[assembly: AssemblyFileVersion("0.9.4.0")]
 [assembly: NeutralResourcesLanguage("en")]

--- a/BananaModManager/Properties/AssemblyInfo.cs
+++ b/BananaModManager/Properties/AssemblyInfo.cs
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.9.4.0")]
-[assembly: AssemblyFileVersion("0.9.4.0")]
+[assembly: AssemblyVersion("0.9.5.0")]
+[assembly: AssemblyFileVersion("0.9.5.0")]
 [assembly: NeutralResourcesLanguage("en")]

--- a/BananaModManager/packages.config
+++ b/BananaModManager/packages.config
@@ -1,7 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Bcl.AsyncInterfaces" version="5.0.0" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net472" />
+  <package id="SharpZipLib" version="1.4.2" targetFramework="net472" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net461" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net472" />
+  <package id="System.IO.Compression.ZipFile" version="4.3.0" targetFramework="net472" />
   <package id="System.Memory" version="4.5.4" targetFramework="net461" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net461" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" targetFramework="net461" />

--- a/LegalMods.md
+++ b/LegalMods.md
@@ -1,7 +1,7 @@
 # List of Speedrun Legal Mods
 
 - Graphical Tweaks: https://gamebanana.com/mods/327537
-- No Helper Prompt (Only legal for the purpose of IL submissions, use with caution): https://gamebanana.com/mods/326845
+- No Helper Prompt (Only legal for the purpose of IL submissions, use with caution): https://gamebanana.com/mods/327404
 - Dynamic Sounds: https://gamebanana.com/mods/327614
 - Guest Character Voice Pack: https://gamebanana.com/mods/331507
 - Timer Sound: https://gamebanana.com/sounds/56772

--- a/LegalMods.md
+++ b/LegalMods.md
@@ -7,3 +7,5 @@
 - Timer Sound: https://gamebanana.com/sounds/56772
 - UI Enhancements: https://gamebanana.com/mods/382591 
 - Indivdual Level Battle Timer: https://gamebanana.com/mods/428681
+
+A full collection of all legal mods will be included with each [release](https://github.com/iswimfly/BananaModManager/releases)

--- a/LegalMods.md
+++ b/LegalMods.md
@@ -1,0 +1,9 @@
+# List of Speedrun Legal Mods
+
+- Graphical Tweaks: https://gamebanana.com/mods/327537
+- No Helper Prompt (Only legal for the purpose of IL submissions, use with caution): https://gamebanana.com/mods/326845
+- Dynamic Sounds: https://gamebanana.com/mods/327614
+- Guest Character Voice Pack: https://gamebanana.com/mods/331507
+- Timer Sound: https://gamebanana.com/sounds/56772
+- UI Enhancements: https://gamebanana.com/mods/382591 
+- Indivdual Level Battle Timer: https://gamebanana.com/mods/428681

--- a/README.md
+++ b/README.md
@@ -22,19 +22,19 @@ If you need some mods to use this mod manager with, check Mors' [BananaBlitzHDMo
 
 I'm currently busy with other projects to maintain this project on a regular basis, so I cannot guarantee when these features will arrive (if ever).
 
-If you have a question, or want to help please reach out to me on the [Banana Mania Modding Discord](https://discord.gg/vuZWDMzzye). Make sure to ping `@Mors#3278` so I see your message!
+If you have a question, or want to help please reach out to me on the [Banana Mania Modding Discord](https://discord.gg/vuZWDMzzye). Make sure to ping `@iswimfly#0556` or `@Mors#3278` so your message is seen!
 
 This project is licensed under GPLv3.
 
 ## Installation
-Download the release from the [releases](https://github.com/MorsGames/BananaModManager/releases) section and extract the contents of the "Release" folder inside the zip to the same folder as the game's executable.
+Download the release from the [releases](https://github.com/iswimfly/BananaModManager/releases) section and extract the contents of the "Release" folder inside the zip to the same folder as the game's executable.
 
 Don't put the mod loader to a different folder than the game's executable, otherwise it won't work.
 
 To install the mods, create a folder called "mods" and extract the zip files there. Each mod should be in their own folder.
 
 ## Making Mods
-Check the [BananaBlitzHDMods](https://github.com/MorsGames/BananaBlitzHDMods) and [BananaManiaMods](https://github.com/MorsGames/BananaManiaMods) repositories to see some example mods.
+Check Mors' [BananaBlitzHDMods](https://github.com/MorsGames/BananaBlitzHDMods) and [BananaManiaMods](https://github.com/MorsGames/BananaManiaMods) repositories, or my [iswimflyBananaManiaMods](https://github.com/iswimfly/iswimflyBananaManiaMods) repository to see some example mods.
 
 A full guide is coming soon. Maybe. 
 
@@ -42,6 +42,7 @@ Or maybe not.
 
 ## Credits
 - [Mors](http://mors-games.com): Programming
+- [iswimfly](https://www.twitch.tv/iswimfly556): Speedrun Mode fixes
 
 ### Open Source Projects Used:
 - [UnityDoorstop](https://github.com/NeighTools/UnityDoorstop)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BananaModManager v0.9.3
 
-A mod manager for Super Monkey Ball games that are made in Unity.
+A mod manager for Super Monkey Ball games that are made in Unity. (Mors has built the entirety of this project, I've forked to make some minor tweaks)
 
 GameBanana Page: [SMB:BBHD](https://gamebanana.com/tools/7464) | [SMB:BM](https://gamebanana.com/tools/7542)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ GameBanana Page: [SMB:BBHD](https://gamebanana.com/tools/7464) | [SMB:BM](https:
 
 **This project is currently is still in beta and is not finished! As of right now, it only supports mods that make use of code injection.**
 
-If you need some mods to use this mod manager with, check my [BananaBlitzHDMods](https://github.com/MorsGames/BananaBlitzHDMods) and [BananaManiaMods](https://github.com/MorsGames/BananaManiaMods) repositories.
+If you need some mods to use this mod manager with, check Mors' [BananaBlitzHDMods](https://github.com/MorsGames/BananaBlitzHDMods) and [BananaManiaMods](https://github.com/MorsGames/BananaManiaMods) repositories, or my [iswimflyBananaManiaMods](https://github.com/iswimfly/iswimflyBananaManiaMods).
 
 ### Currently Supported Games
 - [Super Monkey Ball: Banana Blitz HD](https://store.steampowered.com/app/1061730/Super_Monkey_Ball_Banana_Blitz_HD)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# BananaModManager v0.9.3
+# BananaModManager
 
 A mod manager for Super Monkey Ball games that are made in Unity. (Mors has built the entirety of this project, I've forked to make some minor tweaks)
 


### PR DESCRIPTION
- Updated "Speedrun Mode" to now properly enable in-game leaderboards when legal mods are in use.
- Fixed an oversight that allowed for an advanced method of cheating.
- Removed the in-game hashes that could overlap visually with the loaded mods. Hashes are handled internally now on startup.
- Added the Individual Level Battle Timer to the list of speedrun legal mods in Banana Mania.