### PR TITLE
Replace Join Discord with Refresh Mod List, moved Discord server link to About

### DIFF
--- a/BananaModManager/MainForm.Designer.cs
+++ b/BananaModManager/MainForm.Designer.cs
@@ -309,7 +309,7 @@ namespace BananaModManager
             this.BtnDiscord.Name = "BtnDiscord";
             this.BtnDiscord.Size = new System.Drawing.Size(102, 26);
             this.BtnDiscord.TabIndex = 10;
-            this.BtnDiscord.Text = "Join Discord";
+            this.BtnDiscord.Text = "Reload Mods";
             this.BtnDiscord.Click += new System.EventHandler(this.BtnDiscord_Click);
             // 
             // BtnSaveAndPlay

--- a/BananaModManager/MainForm.Designer.cs
+++ b/BananaModManager/MainForm.Designer.cs
@@ -309,7 +309,7 @@ namespace BananaModManager
             this.BtnDiscord.Name = "BtnDiscord";
             this.BtnDiscord.Size = new System.Drawing.Size(102, 26);
             this.BtnDiscord.TabIndex = 10;
-            this.BtnDiscord.Text = "Reload Mods";
+            this.BtnDiscord.Text = "Refresh List";
             this.BtnDiscord.Click += new System.EventHandler(this.BtnDiscord_Click);
             // 
             // BtnSaveAndPlay

--- a/BananaModManager/MainForm.cs
+++ b/BananaModManager/MainForm.cs
@@ -358,9 +358,10 @@ namespace BananaModManager
             DeleteMod();
         }
 
+        // the fact that this still references the discord server internally could become an issue later, but it's fine for right now (i will regret saying this later)
         private void BtnDiscord_Click(object sender, EventArgs e)
         {
-            Process.Start("https://discord.gg/vuZWDMzzye");
+            LoadMods();
         }
 
         private void BtnSave2_Click(object sender, EventArgs e)

--- a/BananaModManager/MainForm.resx
+++ b/BananaModManager/MainForm.resx
@@ -125,6 +125,8 @@
   </metadata>
   <data name="TextInfo.Text" xml:space="preserve">
     <value>A mod manager for Super Monkey Ball games that are made in Unity.
+Discord Server:
+https://discord.gg/vuZWDMzzye
 
 Credits:
 --------


### PR DESCRIPTION
Quality of life change which makes leaving the mod loader on continuously feasible. By moving the Discord server link to the About tab, nothing is really lost here.

This could definitely be implemented better, however for now this works, I think.